### PR TITLE
fix missing attributes for spots and meshes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <scm>
         <connection>scm:git:git://github.com/UU-cellbiology/bigvolumebrowser</connection>
         <developerConnection>scm:git:git@github.com:UU-cellbiology/bigvolumebrowser</developerConnection>
-        <tag>bigvolumebrowser-0.0.2</tag>
+        <tag>bigvolumebrowser-0.0.3</tag>
         <url>https://github.com/UU-cellbiology/bigvolumebrowser</url>
     </scm>
     <issueManagement>

--- a/src/main/java/bvb/core/BVBSettings.java
+++ b/src/main/java/bvb/core/BVBSettings.java
@@ -35,7 +35,7 @@ import ij.Prefs;
 public class BVBSettings
 {
 	
-	public static String sVersion = "0.0.2";
+	public static String sVersion = "0.0.3";
 	
 	/** background color of BVV canvas **/
 	public static Color canvasBGColor = new Color((int)Prefs.get( "BVB.canvasBGColor", Color.BLACK.getRGB() ));

--- a/src/main/java/bvb/scene/VisMesh.java
+++ b/src/main/java/bvb/scene/VisMesh.java
@@ -347,10 +347,12 @@ public class VisMesh extends AbstractClipTransformVis
 		gl.glVertexAttribPointer( 1, 3, GL_FLOAT, false, 3 * Float.BYTES, 0 );
 		gl.glEnableVertexAttribArray( 1 );
 		
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshUVVbo );
-		gl.glVertexAttribPointer( 2, 2, GL_FLOAT, false, 2 * Float.BYTES, 0 );
-		gl.glEnableVertexAttribArray( 2 );
-
+		if(bHasTexture)
+		{
+			gl.glBindBuffer( GL.GL_ARRAY_BUFFER, meshUVVbo );
+			gl.glVertexAttribPointer( 2, 2, GL_FLOAT, false, 2 * Float.BYTES, 0 );
+			gl.glEnableVertexAttribArray( 2 );
+		}
 		
 		gl.glBindBuffer( GL.GL_ELEMENT_ARRAY_BUFFER, meshEbo );
 		gl.glBindVertexArray( 0 );

--- a/src/main/java/bvb/scene/VisPolyLineAA.java
+++ b/src/main/java/bvb/scene/VisPolyLineAA.java
@@ -288,14 +288,14 @@ public class VisPolyLineAA
 				vertAll[nDup*3+d] = vertices[d];
 			}
 		}
-		for(int nDup = 0; nDup<2; nDup++)
+		for(int nDup = 0; nDup < 2; nDup++)
 		{
 			for (int d = 0; d < 3; d++)
 			{	
 				vertAll[(nPointsN+1)*6 + nDup*3 + d] = vertices[(nPointsN-1)*3 + d];
 			}
 		}
-		for(int i = 0; i<  nTotLength; i++)
+		for(int i = 0; i < nTotLength; i++)
 		{
 			vertCurr[i] = vertAll[i+6];
 			vertPrev[i] = vertAll[i];
@@ -303,7 +303,7 @@ public class VisPolyLineAA
 		}
 		
 		//cumulative length
-		for(int i = 1; i<nPointsN;i++)
+		for(int i = 1; i < nPointsN; i++)
 		{
 			double dLen = 0;
 			for(int d = 0; d < 3; d++)

--- a/src/main/java/bvb/scene/VisSpots.java
+++ b/src/main/java/bvb/scene/VisSpots.java
@@ -416,13 +416,18 @@ public class VisSpots extends AbstractClipTransformVis
 		gl.glVertexAttribPointer( 0, 3, GL_FLOAT, false, 3 * Float.BYTES, 0 );
 		gl.glEnableVertexAttribArray( 0 );
 		
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, sizeVbo );
-		gl.glVertexAttribPointer( 1, 1, GL_FLOAT, false, Float.BYTES, 0 );
-		gl.glEnableVertexAttribArray( 1 );
-		
-		gl.glBindBuffer( GL.GL_ARRAY_BUFFER, propertyVbo );
-		gl.glVertexAttribPointer( 2, 1, GL_FLOAT, false, Float.BYTES, 0 );
-		gl.glEnableVertexAttribArray( 2 );
+		if( fSpotSize < 0.0f )
+		{
+			gl.glBindBuffer( GL.GL_ARRAY_BUFFER, sizeVbo );
+			gl.glVertexAttribPointer( 1, 1, GL_FLOAT, false, Float.BYTES, 0 );
+			gl.glEnableVertexAttribArray( 1 );
+		}
+		if( property != null )
+		{		
+			gl.glBindBuffer( GL.GL_ARRAY_BUFFER, propertyVbo );
+			gl.glVertexAttribPointer( 2, 1, GL_FLOAT, false, Float.BYTES, 0 );
+			gl.glEnableVertexAttribArray( 2 );
+		}
 		
 		gl.glBindVertexArray( 0 );
 		

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -1,1 +1,1 @@
-Plugins, "BigVolumeBrowser 0.0.2", bvb.core.BigVolumeBrowser
+Plugins, "BigVolumeBrowser 0.0.3", bvb.core.BigVolumeBrowser


### PR DESCRIPTION
`glEnableVertexAttribArray` on an empty buffer works on laptop GPU, but not on NVidia,
this PR fixes it.